### PR TITLE
Add check for socket object

### DIFF
--- a/components/realtime/websocket.vue
+++ b/components/realtime/websocket.vue
@@ -147,7 +147,9 @@ export default {
       }
     },
     disconnect() {
-      this.socket.close()
+      if (this.socket) {
+        this.socket.close()
+      }
     },
     handleError(error) {
       this.disconnect()


### PR DESCRIPTION
Fixes a bug where if the socket URL is not reachable, the log window shows "Connecting" indefinitely, with no error message.

Steps to reproduce:
1. Go to [hoppscotch.io](https://hoppscotch.io)
2. Navigate to the Realtime page
3. In the Request URL box, enter an invalid URL, for example `s` or `dfgkjhfhkgfhk`
4. Click the Connect button

Expected behaviour: Error is printed in the log window
Actual behaviour: Log window shows "Connecting to <entered_value>" and freezes, while the following error is printed on the console:

```
TypeError: Cannot read property 'close' of null
    at f.disconnect (f8bbf32.js:1)
    at f.handleError (f8bbf32.js:1)
    at f.connect (f8bbf32.js:1)
    at f.toggleConnection (f8bbf32.js:1)
    at Qt (29d1d29.js:2)
    at HTMLButtonElement.n (29d1d29.js:2)
    at HTMLButtonElement.c._wrapper (29d1d29.js:2)
```